### PR TITLE
support CamelCase for param names in routers

### DIFF
--- a/sanic_routing/patterns.py
+++ b/sanic_routing/patterns.py
@@ -7,7 +7,7 @@ def parse_date(d):
     return datetime.strptime(d, "%Y-%m-%d").date()
 
 
-REGEX_PARAM_NAME = re.compile(r"^<([a-z_]+)(?::(.*))?>$")
+REGEX_PARAM_NAME = re.compile(r"^<([a-zA-Z_]+)(?::(.*))?>$")
 REGEX_TYPES = {
     "string": (str, re.compile(r"^[^/]+")),
     "int": (int, re.compile(r"^-?\d+")),

--- a/sanic_routing/patterns.py
+++ b/sanic_routing/patterns.py
@@ -7,7 +7,7 @@ def parse_date(d):
     return datetime.strptime(d, "%Y-%m-%d").date()
 
 
-REGEX_PARAM_NAME = re.compile(r"^<([a-zA-Z_]+)(?::(.*))?>$")
+REGEX_PARAM_NAME = re.compile(r"^<([a-zA-Z_][a-zA-Z0-9_]*)(?::(.*))?>$")
 REGEX_TYPES = {
     "string": (str, re.compile(r"^[^/]+")),
     "int": (int, re.compile(r"^-?\d+")),

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -140,3 +140,31 @@ def test_conditional_check_proper_compile(handler):
     router.finalize()
 
     assert router.finalized
+
+
+@pytest.mark.parametrize(
+    "param_name",
+    (
+        "fooBar", "foo_bar",
+    ),
+)
+def test_use_param_name(handler, param_name):
+    router = Router()
+    path_part_with_param = f"<{param_name}>"
+    router.add( f"/path/{path_part_with_param}", handler)
+    route = list(router.routes)[0]
+    assert ("path", path_part_with_param) == route
+
+
+@pytest.mark.parametrize(
+    "param_name",
+    (
+        "fooBar", "foo_bar",
+    ),
+)
+def test_use_param_name_with_casing(handler, param_name):
+    router = Router()
+    path_part_with_param = f"<{param_name}:str>"
+    router.add( f"/path/{path_part_with_param}", handler)
+    route = list(router.routes)[0]
+    assert ("path", path_part_with_param) == route

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -145,7 +145,7 @@ def test_conditional_check_proper_compile(handler):
 @pytest.mark.parametrize(
     "param_name",
     (
-        "fooBar", "foo_bar",
+        "fooBar", "foo_bar", "Foobar", "foobar1",
     ),
 )
 def test_use_param_name(handler, param_name):
@@ -159,7 +159,7 @@ def test_use_param_name(handler, param_name):
 @pytest.mark.parametrize(
     "param_name",
     (
-        "fooBar", "foo_bar",
+        "fooBar", "foo_bar", "Foobar", "foobar1",
     ),
 )
 def test_use_param_name_with_casing(handler, param_name):


### PR DESCRIPTION
Add support CamelCase for  param names in routers 