### PR TITLE
Fix routes with different depth

### DIFF
--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -289,7 +289,10 @@ class BaseRouter(ABC):
         for num, line in enumerate(src):
             if line.indent < current:
                 if not line.src.startswith("."):
-                    offset = 0
+                    if offset < 0:
+                        offset += 1
+                    else:
+                        offset = 0
 
             if (
                 line.src.startswith("if")


### PR DESCRIPTION
Fix _find_route function generation when two route are overlapping and have different depth.
Example:
```
/foo/<foo_id>/bars_ids
/foo/<foo_id>/bars_ids/<bar_id>/settings/<group_id>/groups
```
