### PR TITLE
Add additional depth check on typed route

### DIFF
--- a/sanic_routing/__init__.py
+++ b/sanic_routing/__init__.py
@@ -1,5 +1,5 @@
 from .route import Route
 from .router import BaseRouter
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"
 __all__ = ("BaseRouter", "Route")

--- a/sanic_routing/patterns.py
+++ b/sanic_routing/patterns.py
@@ -10,10 +10,10 @@ def parse_date(d):
 REGEX_PARAM_NAME = re.compile(r"^<([a-zA-Z_][a-zA-Z0-9_]*)(?::(.*))?>$")
 REGEX_TYPES = {
     "string": (str, re.compile(r"^[^/]+")),
-    "int": (int, re.compile(r"^-?\d+")),
-    "number": (float, re.compile(r"^-?(?:\d+(?:\.\d*)?|\.\d+)")),
     "alpha": (str, re.compile(r"^[A-Za-z]+")),
     "path": (str, re.compile(r"^[^/]?.*?")),
+    "number": (float, re.compile(r"^-?(?:\d+(?:\.\d*)?|\.\d+)")),
+    "int": (int, re.compile(r"^-?\d+")),
     "ymd": (
         parse_date,
         re.compile(r"^([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))"),

--- a/sanic_routing/route.py
+++ b/sanic_routing/route.py
@@ -169,7 +169,9 @@ class Route:
                 f"Duplicate named parameters in: {self._raw_path}"
             )
         self.labels = labels
-        self.params = params
+        self.params = dict(
+            sorted(params.items(), key=lambda param: self._sorting(param[1]))
+        )
 
     def _finalize_methods(self):
         self.methods = set()

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -299,6 +299,7 @@ class BaseRouter(ABC):
                 or line.src.startswith("elif")
                 or line.src.startswith("return")
                 or line.src.startswith("basket")
+                or line.src.startswith("try")
             ):
 
                 idnt = line.indent + 1

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -250,6 +250,8 @@ class BaseRouter(ABC):
                 ]
             ]
 
+        src.append(Line("raise NotFound", 1))
+
         self.optimize(src)
 
         self.find_route_src = "".join(
@@ -284,8 +286,16 @@ class BaseRouter(ABC):
         and realign lines to proper indentation
         """
         offset = 0
+        current = 0
         insert_at = set()
         for num, line in enumerate(src):
+            if line.indent < current:
+                if not line.src.startswith("."):
+                    if offset < 0:
+                        offset += 1
+                    else:
+                        offset = 0
+
             if (
                 line.src.startswith("if")
                 or line.src.startswith("elif")
@@ -293,6 +303,7 @@ class BaseRouter(ABC):
                 or line.src.startswith("basket")
                 or line.src.startswith("try")
             ):
+
                 idnt = line.indent + 1
                 prev_line = src[num - 1]
                 while idnt < prev_line.indent:
@@ -301,6 +312,7 @@ class BaseRouter(ABC):
 
             offset += line.offset
             line.indent += offset
+            current = line.indent
 
         idnt = 1
         prev_line = src[-1]

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -284,16 +284,8 @@ class BaseRouter(ABC):
         and realign lines to proper indentation
         """
         offset = 0
-        current = 0
         insert_at = set()
         for num, line in enumerate(src):
-            if line.indent < current:
-                if not line.src.startswith("."):
-                    if offset < 0:
-                        offset += 1
-                    else:
-                        offset = 0
-
             if (
                 line.src.startswith("if")
                 or line.src.startswith("elif")
@@ -309,7 +301,6 @@ class BaseRouter(ABC):
 
             offset += line.offset
             line.indent += offset
-            current = line.indent
 
         idnt = 1
         prev_line = src[-1]

--- a/sanic_routing/router.py
+++ b/sanic_routing/router.py
@@ -301,7 +301,6 @@ class BaseRouter(ABC):
                 or line.src.startswith("basket")
                 or line.src.startswith("try")
             ):
-
                 idnt = line.indent + 1
                 prev_line = src[num - 1]
                 while idnt < prev_line.indent:

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -73,8 +73,10 @@ class Node:
         return_bump = 1
 
         if self.first or self.root:
+            src = []
             operation = ">"
             use_level = level
+            conditional = "if"
             if (
                 self.last
                 and self.route
@@ -85,7 +87,16 @@ class Node:
                 use_level = self.level
                 operation = "=="
                 equality_check = True
-            src = [Line(f"if num {operation} {use_level}:", indent)]
+                conditional = "elif"
+                src.extend(
+                    [
+                        Line(f"if num > {use_level}:", indent),
+                        Line("raise NotFound", indent + 1),
+                    ]
+                )
+            src.append(
+                Line(f"{conditional} num {operation} {use_level}:", indent)
+            )
 
         if self.dynamic:
             if not self.parent.children_basketed:

--- a/sanic_routing/tree.py
+++ b/sanic_routing/tree.py
@@ -122,8 +122,6 @@ class Node:
                 if not self.children and not equality_check
                 else ""
             )
-            if if_stmt == "elif":
-                src.append(Line("...", 0, offset=0, render=False))
             src.append(
                 Line(
                     f'{if_stmt} parts[{level}] == "{self.part}"{len_check}:',
@@ -161,15 +159,6 @@ class Node:
                         return_indent,
                     ),
                 ]
-            )
-            # This is a control line to help control indentation, but
-            # it should not be rendered
-            location.append(
-                Line(
-                    "...",
-                    indent + return_bump + bool(not self.children),
-                    render=False,
-                )
             )
         return src, delayed
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -222,7 +222,7 @@ def test_use_route_with_different_depth(handler):
     router.get("/foo/123/bars_ids/321/settings/111/groups", "BASE")
 
 
-def test_use_route_type_coersion(handler):
+def test_use_route_type_coercion(handler):
     router = Router()
     router.add("/test/<foo:int>", handler)
     router.add("/test/<foo:int>/bar", handler)
@@ -238,3 +238,31 @@ def test_use_route_type_coersion(handler):
         router.get("/test/123/aaaa", "BASE")
     with pytest.raises(NotFound):
         router.get("/test/123/aaaa/bbbb", "BASE")
+
+
+def test_use_route_type_coercion_deeper(handler):
+    router = Router()
+    router.add("/test/<foo:int>", handler)
+    router.add("/test/<foo:int>/bar", handler)
+    router.add("/test/<foo:int>/bar/baz", handler)
+
+    router.finalize()
+
+    router.get("/test/123", "BASE")
+    router.get("/test/123/bar", "BASE")
+    router.get("/test/123/bar/baz", "BASE")
+
+    with pytest.raises(NotFound):
+        router.get("/test/foo/aaaa", "BASE")
+    with pytest.raises(NotFound):
+        router.get("/test/123/aaaa", "BASE")
+    with pytest.raises(NotFound):
+        router.get("/test/123/aaaa/bbbb", "BASE")
+    with pytest.raises(NotFound):
+        router.get("/test/123/aaaa/bbbb/cccc", "BASE")
+    with pytest.raises(NotFound):
+        router.get("/test/foo/bar", "BASE")
+    with pytest.raises(NotFound):
+        router.get("/test/123/bar/bbbb", "BASE")
+    with pytest.raises(NotFound):
+        router.get("/test/123/bar/bbbb/cccc", "BASE")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -232,9 +232,6 @@ def test_use_route_type_coercion(handler):
     router.add("/test/<foo:int>", handler)
     router.add("/test/<foo:int>/bar", handler)
 
-    router.finalize(False)
-    print(router.find_route_src)
-    router.reset()
     router.finalize()
 
     router.get("/test/123", "BASE")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -113,7 +113,7 @@ def test_cast_types_at_same_position(handler):
 @pytest.mark.parametrize(
     "label,value,cast_type",
     (
-        ("string", "foo", str),
+        ("string", "foo_-", str),
         ("int", 11111, int),
         ("number", 99.99, float),
         ("alpha", "ABCxyz", str),
@@ -123,7 +123,12 @@ def test_cast_types_at_same_position(handler):
 )
 def test_casting(handler, label, value, cast_type):
     router = Router()
-    router.add(f"/<foo:{label}>", handler)
+    router.add("/<foo:string>", handler)
+    router.add("/<foo:int>", handler)
+    router.add("/<foo:number>", handler)
+    router.add("/<foo:alpha>", handler)
+    router.add("/<foo:ymd>", handler)
+    router.add("/<foo:uuid>", handler)
 
     router.finalize()
     _, handler, params = router.get(f"/{value}", "BASE")
@@ -227,6 +232,9 @@ def test_use_route_type_coercion(handler):
     router.add("/test/<foo:int>", handler)
     router.add("/test/<foo:int>/bar", handler)
 
+    router.finalize(False)
+    print(router.find_route_src)
+    router.reset()
     router.finalize()
 
     router.get("/test/123", "BASE")


### PR DESCRIPTION
Fixes #16 

```python
@app.route("/test/<foo:int>")
async def one(request, user_id, id_num):
    return text("one")


@app.route("/test/<foo:int>/bar")
async def two(request, user_id, id_num):
    return text("two")
```

```
def find_route(path, router, basket, extra):
    parts = tuple(path[1:].split(router.delimiter))
    num = len(parts)
    if num > 0:
        if parts[0] == "test":
            if num > 1:
                basket[1] = parts[1]
                if num > 3:
                    raise NotFound
                elif num == 3:
                    if parts[2] == "bar":
                        try:
                            basket['__params__']['foo'] = int(basket[1])
                        except ValueError:
                            ...
                        else:
                            basket['__raw_path__'] = 'test/<foo:int>/bar'
                            return router.dynamic_routes[('test', '<foo:int>', 'bar')], basket
                    raise NotFound
                try:
                    basket['__params__']['foo'] = int(basket[1])
                except ValueError:
                    ...
                else:
                    basket['__raw_path__'] = 'test/<foo:int>'
                    return router.dynamic_routes[('test', '<foo:int>')], basket
            raise NotFound
        raise NotFound
    raise NotFound

Requested URL /test/123 (<Route: name=__main__.one path=test/<foo:int>>, <function one at 0x7f4421a8fe50>, {'foo': 123})
Requested URL /test/123/bar (<Route: name=__main__.two path=test/<foo:int>/bar>, <function two at 0x7f4420cd5940>, {'foo': 123})
Requested URL /test/foo/aaaa not found
Requested URL /test/0/aaaa not found
Requested URL /test/0/aaaa/bbbb not found
```

Before proceeding, I want to test this against Sanic `main` some.